### PR TITLE
fix: test/load.rb: Struct.new needs a name

### DIFF
--- a/test/load.rb
+++ b/test/load.rb
@@ -50,7 +50,7 @@ Regexp = Class.new do
     @option
   end
 end unless Object.const_defined? :Regexp
-Struct::Pyramid = Struct.new
+Struct::Pyramid = Struct.new('Pyramid')
 
 assert('Marshal.load') do
   assert_equal Marshal.load("\x04\b0"), nil


### PR DESCRIPTION
When building with current mruby stable I was getting an error. This patch fixed it.

Cheers, Srdjan