### PR TITLE
fix(load): sequence kh_put before kh_value store in r_prepare (unsequenced realloc -> heap corruption)

### DIFF
--- a/src/load.c
+++ b/src/load.c
@@ -50,8 +50,13 @@ static mrb_sym r_symbol(mrb_state *, struct load_arg *);
 
 static mrb_int r_prepare(mrb_state *mrb, struct load_arg *arg) {
   mrb_int idx = kh_size(arg->data);
-  kh_value(object_load_table, arg->data,
-           kh_put(object_load_table, mrb, arg->data, idx)) = mrb_undef_value();
+  /* kh_put() may grow the table and realloc its bucket arrays. Evaluating the
+   * kh_value() lvalue (which dereferences the bucket base pointer) in the same
+   * statement as the kh_put() call is unsequenced, so the store can be made
+   * through a stale/freed bucket pointer -> intermittent heap corruption.
+   * Sequence the two with an explicit local, as r_entry0() already does. */
+  khint_t k = kh_put(object_load_table, mrb, arg->data, idx);
+  kh_value(object_load_table, arg->data, k) = mrb_undef_value();
   return idx;
 }
 


### PR DESCRIPTION
## Summary

`r_prepare()` in `src/load.c` reserves an object-link-table slot with the
`kh_put()` call inlined inside the `kh_value()` lvalue:

```c
kh_value(object_load_table, arg->data,
         kh_put(object_load_table, mrb, arg->data, idx)) = mrb_undef_value();
```

`kh_put()` can grow the khash and **realloc** its bucket arrays. `kh_value(h, x)`
expands to an lvalue that dereferences the bucket base pointer (`h->vals`).
Evaluating that base pointer and the `kh_put()` call within the **same**
statement is unsequenced, so the compiler is free to load the *old* `h->vals`
before `kh_put()` reallocates it and then perform the store through the
**stale (freed) pointer**. When an insertion happens to cross a resize
threshold during `Marshal.load` of a larger object graph, this corrupts the
heap.

This is the same class of bug that PR #4 ("fix UB caused by expression
evaluation order") fixed in `dump.c`. Notably, `r_entry0()` in this same file
is already written in the safe two-statement form — `r_prepare()` was the one
remaining site.

## Fix

Sequence `kh_put()` into an explicit local before forming the `kh_value()`
lvalue, exactly mirroring the existing `r_entry0()`:

```c
khint_t k = kh_put(object_load_table, mrb, arg->data, idx);
kh_value(object_load_table, arg->data, k) = mrb_undef_value();
```

One file, +7/-2 (the extra lines are an explanatory comment).

## Reproduction / Evidence

Built against **mruby 4.0.0** and run as a native gem inside a
`Marshal.load`-heavy embedding (an RPG Maker VX Ace / RGSS3 runtime that
`Marshal.load`s its data files on every boot). Headless boot repeated 15x per
variant, only `src/load.c` swapped, everything else identical:

| `r_prepare()` form | boots | crashes |
|---|---|---|
| current `master` (inlined `kh_put`) | 15 | **5** (~33%) — `STATUS_ACCESS_VIOLATION` 0xC0000005 / `STATUS_HEAP_CORRUPTION` 0xC0000374 |
| this PR (split) | 15 | **0** |

The crash is intermittent and data-dependent precisely because it only triggers
when that particular `kh_put()` causes a resize, which matches the
unsequenced-evaluation analysis.

## Notes

The realloc-invalidates-the-lvalue hazard is latent on any toolchain but became
easy to hit when building against mruby 4.0.0's khash. The fix is a pure
sequencing change with no behavioral difference on the non-resize path.
